### PR TITLE
Refactored how the tenant id is set and used

### DIFF
--- a/src/AuraIsHere/LaravelMultiTenant/ScopedByTenant.php
+++ b/src/AuraIsHere/LaravelMultiTenant/ScopedByTenant.php
@@ -36,23 +36,6 @@ trait ScopedByTenant {
 	}
 
 	/**
-	 * Get the value to scope the "tenant id" with.
-	 *
-	 * @return string
-	 */
-	public function getTenantId()
-	{
-		// Make sure we can actually get a tenant id
-		if (! is_callable(Config::get('laravel-multi-tenant::tenant_id')))
-		{
-			throw new RuntimeException('The tenant_id config setting must be callable');
-		}
-
-		// Call the tenant_id closure to get the actual id.
-		return call_user_func(Config::get('laravel-multi-tenant::tenant_id'));
-	}
-
-	/**
 	 * Get the name of the "tenant id" column.
 	 *
 	 * @return string
@@ -80,7 +63,10 @@ trait ScopedByTenant {
 	 */
 	public function getTenantWhereClause()
 	{
-		return "{$this->getQualifiedTenantColumn()} = '{$this->getTenantId()}'";
+		$tenantColumn = $this->getQualifiedTenantColumn();
+		$tenantId     = TenantScope::getTenantId();
+
+		return "{$tenantColumn} = '{$tenantId}'";
 	}
 
 	/**

--- a/src/AuraIsHere/LaravelMultiTenant/TenantScope.php
+++ b/src/AuraIsHere/LaravelMultiTenant/TenantScope.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Query\Expression;
 
 class TenantScope implements ScopeInterface {
 
+	private static $tenantId;
+
 	/**
 	 * Apply the scope to a given Eloquent query builder.
 	 *
@@ -15,10 +17,12 @@ class TenantScope implements ScopeInterface {
 	 */
 	public function apply(Builder $builder)
 	{
+		if (is_null(static::$tenantId)) return;
+
 		/** @var \Illuminate\Database\Eloquent\Model|ScopedByTenant $model */
 		$model = $builder->getModel();
 
-		// Use whereRaw instead of where to avoind issue with bindings when removing
+		// Use whereRaw instead of where to avoid issues with bindings when removing
 		$builder->whereRaw($model->getTenantWhereClause());
 	}
 
@@ -65,5 +69,15 @@ class TenantScope implements ScopeInterface {
 	protected function isTenantConstraint(array $where, $model)
 	{
 		return $where['type'] == 'raw' && $where['sql'] == $model->getTenantWhereClause();
+	}
+
+	public static function getTenantId()
+	{
+		return static::$tenantId;
+	}
+
+	public static function setTenantId($tenantId)
+	{
+		static::$tenantId = $tenantId;
 	}
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -20,26 +20,4 @@ return [
 
 	'tenant_column' => 'company_id',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Tenant ID
-	|--------------------------------------------------------------------------
-	|
-	| You'll also need to specify how to get the tenant id. This could be
-	| done in any number of ways. You could get the tenant id from the logged
-	| in user:
-	|
-	|     Auth::user()->company_id
-	|
-	| or maybe you've got it stored in your Session somewhere:
-	|
-	|     Session::get('company_id')
-	|
-	*/
-
-	'tenant_id' => function ()
-	{
-		return Auth::user()->company_id;
-	}
-
 ];


### PR DESCRIPTION
I've come up with this as a potential solution to #2.

Instead of providing a callback in the config to retrieve the tenant id, you would have to call `TenantScope::setTenantId($tenantId)` to set it on login, or whatever other event requires you to set/change the current tenant.

If `TenantScope::$tenant_id` is not set, it'll just return from the `apply()` method and not scope the request. This is nessecary for cases where you may want to log out and then log in a different user – the second login request cannot be scoped or it is likely to fail.

It works okay, and is nice and flexible, but I'm not sure if I like how it leaves you open to forget to set (or accidentally unset) the tenant id.

Thoughts?
