### PR TITLE
Fix config name at TenantScopedModelTrait

### DIFF
--- a/src/AuraIsHere/LaravelMultiTenant/Traits/TenantScopedModelTrait.php
+++ b/src/AuraIsHere/LaravelMultiTenant/Traits/TenantScopedModelTrait.php
@@ -48,7 +48,7 @@ trait TenantScopedModelTrait
      */
     public function getTenantColumns()
     {
-        return isset($this->tenantColumns) ? $this->tenantColumns : config('multi-tenant.default_tenant_columns');
+        return isset($this->tenantColumns) ? $this->tenantColumns : config('tenant.default_tenant_columns');
     }
 
     /**


### PR DESCRIPTION
When publishing with L5, the config file is named **tenant**, so it should be used to get the config, instead of **multi-tenant**, which returns nothing in this case.

```
Copied File [/vendor/aura-is-here/laravel-multi-tenant/src/config/config.php] To [/config/tenant.php]
```