### PR TITLE
Composer fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,8 @@
         "laravel/framework": "4.2.*|5.0.*|5.1.*"
     },
     "autoload": {
-        "psr-0": {
-            "AuraIsHere\\LaravelMultiTenant\\": "src/"
+        "psr-4": {
+            "AuraIsHere\\LaravelMultiTenant\\": "src/AuraIsHere/LaravelMultiTenant/"
         }
-    },
-    "minimum-stability": "stable"
+    }
 }


### PR DESCRIPTION
`"minimum-stability": "stable"` is the default and psr0 is deprecated.