### PR TITLE
Feijs issue62 master

### DIFF
--- a/src/AuraIsHere/LaravelMultiTenant/Contracts/LoftyScope.php
+++ b/src/AuraIsHere/LaravelMultiTenant/Contracts/LoftyScope.php
@@ -1,9 +1,12 @@
-<?php namespace AuraIsHere\LaravelMultiTenant\Contracts;
+<?php
+
+namespace AuraIsHere\LaravelMultiTenant\Contracts;
 
 /**
- * A global scope which should not be a subquery
+ * A global scope which should not be a subquery.
  *
- * @package AuraIsHere\LaravelMultiTenant
  * @author  Mike Feijs <mike@feijs.nl>
  */
-interface LoftyScope {}
+interface LoftyScope
+{
+}

--- a/src/AuraIsHere/LaravelMultiTenant/LaravelMultiTenantServiceProvider.php
+++ b/src/AuraIsHere/LaravelMultiTenant/LaravelMultiTenantServiceProvider.php
@@ -22,7 +22,7 @@ class LaravelMultiTenantServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/../../config/config.php' => config_path('tenant.php'),
+            __DIR__.'/../../config/config.php' => config_path('tenant.php'),
         ]);
     }
 
@@ -34,7 +34,7 @@ class LaravelMultiTenantServiceProvider extends ServiceProvider
     public function register()
     {
         // Merge the package config values so they don't have to have a complete configuration
-        $this->mergeConfigFrom(__DIR__ . '/../../config/config.php', 'tenant');
+        $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'tenant');
 
         // Register our tenant scope instance
         $this->app->singleton('AuraIsHere\LaravelMultiTenant\TenantScope', function ($app) {

--- a/src/AuraIsHere/LaravelMultiTenant/TenantQueryBuilder.php
+++ b/src/AuraIsHere/LaravelMultiTenant/TenantQueryBuilder.php
@@ -1,103 +1,108 @@
-<?php namespace AuraIsHere\LaravelMultiTenant;
+<?php
 
-use Closure;
-use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\Model;
+namespace AuraIsHere\LaravelMultiTenant;
+
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Str;
 
 class TenantQueryBuilder extends Builder
 {
-	/**
-	 * Nested query for all wheres except the global scopes
-	 * @var \Illuminate\Database\Eloquent\Builder
-	 */
-	protected $nestedWhere = null;
-
-	/**
-	 * These methods should be passed into the nested Where query
-	 * 
-	 * Anything starting with 'where' is already passed to handle dynamicWhere
-	 * Anything with 'has' is already passed into the model's 'where' method
-	 *
-	 * @var string[]
-	 */
-	protected $shouldBeNested = ["orwhereraw", "orwherebetween", "orwherenotbetween", "addnestedsubquery", 
-								 "orwhereexists", "orwherenotexists", "orwherein", "orwherenotin",
-								 "orwherenull","orwherenotnull", "dynamicwhere"
-								];							
-
-	/**
-	 * Set a model instance for the model being queried.
-	 *
-	 * @param  \Illuminate\Database\Eloquent\Model  $model
-	 * @return $this
-	 */
-	public function setModel(Model $model)
-	{
-		$this->model = $model;
-		$this->query->from($model->getTable());
-
-		//Add soft deleting macro's to this builder
-		if(method_exists($this->model, 'bootSoftDeletes')) {
-			$scope = new SoftDeletingScope;
-			$scope->extend($this);
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Add a basic where clause to the nested query.
-	 *
-	 * @param  string  $column
-	 * @param  string  $operator
-	 * @param  mixed   $value
-	 * @param  string  $boolean
-	 * @return $this
-	 */
-	public function where($column, $operator = null, $value = null, $boolean = 'and')
-	{
-		return $this->addToNestedQuery('where', [$column, $operator, $value, $boolean]);
-	}
-
-	/**
-     * Handle dynamic calls which should go into the nested where query
+    /**
+     * Nested query for all wheres except the global scopes.
      *
-     * @param  string  $method
-     * @param  array   $parameters
+     * @var \Illuminate\Database\Eloquent\Builder
+     */
+    protected $nestedWhere = null;
+
+    /**
+     * These methods should be passed into the nested Where query.
+     * 
+     * Anything starting with 'where' is already passed to handle dynamicWhere
+     * Anything with 'has' is already passed into the model's 'where' method
+     *
+     * @var string[]
+     */
+    protected $shouldBeNested = ['orwhereraw', 'orwherebetween', 'orwherenotbetween', 'addnestedsubquery',
+                                 'orwhereexists', 'orwherenotexists', 'orwherein', 'orwherenotin',
+                                 'orwherenull','orwherenotnull', 'dynamicwhere',
+                                ];
+
+    /**
+     * Set a model instance for the model being queried.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return $this
+     */
+    public function setModel(Model $model)
+    {
+        $this->model = $model;
+        $this->query->from($model->getTable());
+
+        //Add soft deleting macro's to this builder
+        if (method_exists($this->model, 'bootSoftDeletes')) {
+            $scope = new SoftDeletingScope();
+            $scope->extend($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a basic where clause to the nested query.
+     *
+     * @param string $column
+     * @param string $operator
+     * @param mixed  $value
+     * @param string $boolean
+     *
+     * @return $this
+     */
+    public function where($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->addToNestedQuery('where', [$column, $operator, $value, $boolean]);
+    }
+
+    /**
+     * Handle dynamic calls which should go into the nested where query.
+     *
+     * @param string $method
+     * @param array  $parameters
+     *
      * @return $this
      */
     protected function addToNestedQuery($method, $parameters)
     {
-    	if(is_null($this->nestedWhere)) 
-    	{
-    		//Create a new (non-tenant) query builder
-    		$query = $this->model->newQueryWithoutScopes();
+        if (is_null($this->nestedWhere)) {
+            //Create a new (non-tenant) query builder
+            $query = $this->model->newQueryWithoutScopes();
 
-    		//Add any existing where bindings
-    		$query->getQuery()->setBindings(['where' => $this->query->getRawBindings()['where']] );
+            //Add any existing where bindings
+            $query->getQuery()->setBindings(['where' => $this->query->getRawBindings()['where']]);
 
-			call_user_func_array(array($query, $method), $parameters); 
+            call_user_func_array([$query, $method], $parameters);
 
-			//Add this new query as a nested where
-			$this->query->addNestedWhereQuery($query->getQuery());
-			$this->nestedWhere = $query;
-			
-		}
-		else call_user_func_array(array($this->nestedWhere, $method), $parameters); 
+            //Add this new query as a nested where
+            $this->query->addNestedWhereQuery($query->getQuery());
+            $this->nestedWhere = $query;
+        } else {
+            call_user_func_array([$this->nestedWhere, $method], $parameters);
+        }
 
-		$this->query->setBindings($this->nestedWhere->getQuery()->getBindings());
+        $this->query->setBindings($this->nestedWhere->getQuery()->getBindings());
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
+    /**
      * Merge the "wheres" from a relation query to a has query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param \Illuminate\Database\Eloquent\Builder            $hasQuery
+     * @param \Illuminate\Database\Eloquent\Relations\Relation $relation
+     *
      * @return void
      */
     protected function mergeWheresToHas(Builder $hasQuery, Relation $relation)
@@ -111,19 +116,19 @@ class TenantQueryBuilder extends Builder
             $relationQuery->wheres, $relationQuery->getBindings()
         );
 
-        if(!is_null($this->nestedWhere)) {
+        if (!is_null($this->nestedWhere)) {
             $this->nestedWhere->mergeBindings($hasQuery->getQuery());
-        }
-        else {
+        } else {
             $this->query->mergeBindings($hasQuery->getQuery());
         }
     }
 
-	 /**
+    /**
      * Dynamically handle calls into the query instance.
      *
-     * @param  string  $method
-     * @param  array   $parameters
+     * @param string $method
+     * @param array  $parameters
+     *
      * @return mixed
      */
     public function __call($method, $parameters)
@@ -132,17 +137,13 @@ class TenantQueryBuilder extends Builder
             array_unshift($parameters, $this);
 
             return call_user_func_array($this->macros[$method], $parameters);
-        } 
-        elseif (method_exists($this->model, $scope = 'scope'.ucfirst($method))) 
-        {
+        } elseif (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {
             return $this->callScope($scope, $parameters);
-        } 
-        elseif( in_array(strtolower($method), $this->shouldBeNested, true) ||
-        		Str::startsWith($method, 'where')) 
-        {
-        	//Catch any nestable methods and pass them to the nested query
-        	return $this->addToNestedQuery($method, $parameters);
-		}
+        } elseif (in_array(strtolower($method), $this->shouldBeNested, true) ||
+                Str::startsWith($method, 'where')) {
+            //Catch any nestable methods and pass them to the nested query
+            return $this->addToNestedQuery($method, $parameters);
+        }
 
         $result = call_user_func_array([$this->query, $method], $parameters);
 

--- a/src/AuraIsHere/LaravelMultiTenant/TenantScope.php
+++ b/src/AuraIsHere/LaravelMultiTenant/TenantScope.php
@@ -2,13 +2,13 @@
 
 namespace AuraIsHere\LaravelMultiTenant;
 
+use AuraIsHere\LaravelMultiTenant\Contracts\LoftyScope;
+use AuraIsHere\LaravelMultiTenant\Exceptions\TenantColumnUnknownException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ScopeInterface;
-use AuraIsHere\LaravelMultiTenant\Contracts\LoftyScope;
-use AuraIsHere\LaravelMultiTenant\Exceptions\TenantColumnUnknownException;
 
-class TenantScope implements ScopeInterface, LoftyScope 
+class TenantScope implements ScopeInterface, LoftyScope
 {
     private $enabled = true;
 
@@ -48,7 +48,7 @@ class TenantScope implements ScopeInterface, LoftyScope
      *
      * @param string $tenantColumn
      *
-     * @return boolean
+     * @return bool
      */
     public function removeTenant($tenantColumn)
     {
@@ -66,7 +66,7 @@ class TenantScope implements ScopeInterface, LoftyScope
      *
      * @param string $tenantColumn
      *
-     * @return boolean
+     * @return bool
      */
     public function hasTenant($tenantColumn)
     {
@@ -83,7 +83,7 @@ class TenantScope implements ScopeInterface, LoftyScope
      */
     public function apply(Builder $builder, Model $model)
     {
-        if (! $this->enabled) {
+        if (!$this->enabled) {
             return;
         }
 
@@ -106,7 +106,7 @@ class TenantScope implements ScopeInterface, LoftyScope
         $query = $builder->getQuery();
 
         foreach ($this->getModelTenants($model) as $tenantColumn => $tenantId) {
-            foreach ((array)$query->wheres as $key => $where) {
+            foreach ((array) $query->wheres as $key => $where) {
                 // If the where clause is a tenant constraint, we will remove it from the query
                 // and reset the keys on the wheres. This allows this developer to include
                 // the tenant model in a relationship result set that is lazy loaded.
@@ -126,7 +126,7 @@ class TenantScope implements ScopeInterface, LoftyScope
     public function creating(Model $model)
     {
         // If the model has had the global scope removed, bail
-        if (! $model->hasGlobalScope($this)) {
+        if (!$model->hasGlobalScope($this)) {
             return;
         }
 
@@ -147,8 +147,8 @@ class TenantScope implements ScopeInterface, LoftyScope
      */
     public function getModelTenants(Model $model)
     {
-        $modelTenantColumns = (array)$model->getTenantColumns();
-        $modelTenants       = [];
+        $modelTenantColumns = (array) $model->getTenantColumns();
+        $modelTenants = [];
 
         foreach ($modelTenantColumns as $tenantColumn) {
             if ($this->hasTenant($tenantColumn)) {
@@ -168,9 +168,9 @@ class TenantScope implements ScopeInterface, LoftyScope
      */
     public function getTenantId($tenantColumn)
     {
-        if (! $this->hasTenant($tenantColumn)) {
+        if (!$this->hasTenant($tenantColumn)) {
             throw new TenantColumnUnknownException(
-                get_class($this->model) . ': tenant column "' . $tenantColumn . '" NOT found in tenants scope "' . json_encode($this->tenants) . '"'
+                get_class($this->model).': tenant column "'.$tenantColumn.'" NOT found in tenants scope "'.json_encode($this->tenants).'"'
             );
         }
 

--- a/tests/TenantQueryBuilderTest.php
+++ b/tests/TenantQueryBuilderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Mockery as m;
 use AuraIsHere\LaravelMultiTenant\TenantQueryBuilder;
+use Mockery as m;
 
 class TenantQueryBuilderTest extends PHPUnit_Framework_TestCase
 {
-	public function tearDown()
+    public function tearDown()
     {
         m::close();
     }
@@ -15,54 +15,54 @@ class TenantQueryBuilderTest extends PHPUnit_Framework_TestCase
      * - The first 'nestable' method call creates a nested query builder, 
      * - both the first and any subsequent 'nestable' method calls are 
      *		passed into this nested builder
-	 * - Any query bindings are also set on the original query
+     * - Any query bindings are also set on the original query.
      */
-	public function testShouldBeNested()
+    public function testShouldBeNested()
     {
-    	/* Expectation */
-		$nestedRawQuery = $this->getMockQueryBuilder();
-		$nestedRawQuery->shouldReceive('getBindings')->twice()->andReturn(['type' => 'value']);
-		$nestedRawQuery->shouldReceive('setBindings')->once()->with([ 'where' => ['flbr' => 1]]);
+        /* Expectation */
+        $nestedRawQuery = $this->getMockQueryBuilder();
+        $nestedRawQuery->shouldReceive('getBindings')->twice()->andReturn(['type' => 'value']);
+        $nestedRawQuery->shouldReceive('setBindings')->once()->with(['where' => ['flbr' => 1]]);
 
-		$nestedQuery = m::mock('Illuminate\Database\Eloquent\Builder');
-		$nestedQuery->shouldReceive('getQuery')->times(4)->andReturn($nestedRawQuery);
-		$nestedQuery->shouldReceive('whereNotBetween')->once()->with('foo', ['bar', 'boo']);
-		$nestedQuery->shouldReceive('whereNull')->once()->with('bah');
-		
-		$model = $this->getMockModel()->makePartial();
-		$model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($nestedQuery);
-		
-		$builder = $this->getBuilder();
-		$builder->getQuery()->shouldReceive('from');
-		$builder->setModel($model);
+        $nestedQuery = m::mock('Illuminate\Database\Eloquent\Builder');
+        $nestedQuery->shouldReceive('getQuery')->times(4)->andReturn($nestedRawQuery);
+        $nestedQuery->shouldReceive('whereNotBetween')->once()->with('foo', ['bar', 'boo']);
+        $nestedQuery->shouldReceive('whereNull')->once()->with('bah');
+
+        $model = $this->getMockModel()->makePartial();
+        $model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($nestedQuery);
+
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('from');
+        $builder->setModel($model);
 
         $builder->getQuery()->shouldReceive('addNestedWhereQuery')->once()->with($nestedRawQuery);
         $builder->getQuery()->shouldReceive('setBindings')->twice()->with(['type' => 'value']);
-        $builder->getQuery()->shouldReceive('getRawBindings')->once()->andReturn([ 'where' => ['flbr' => 1]] );
+        $builder->getQuery()->shouldReceive('getRawBindings')->once()->andReturn(['where' => ['flbr' => 1]]);
 
         /* Execution */
         $result1 = $builder->whereNotBetween('foo', ['bar', 'boo']);
         $result2 = $builder->whereNull('bah');
 
-        /** Assertion */
+        /* Assertion */
         $this->assertEquals($result1, $builder);
         $this->assertEquals($result2, $builder);
     }
 
     /**
      * Test whether:
-     *  'where' calls are passed to the correct function to be nested
+     *  'where' calls are passed to the correct function to be nested.
      */
     public function testSimpleWhere()
     {
-    	$builder = m::mock('AuraIsHere\LaravelMultiTenant\TenantQueryBuilder[addToNestedQuery]', [$this->getMockQueryBuilder()]);
-		$builder->shouldAllowMockingProtectedMethods();
-		$builder->shouldReceive('addToNestedQuery')->once()->with('where', ['foo', null, null, 'and'])->andReturn($builder);
+        $builder = m::mock('AuraIsHere\LaravelMultiTenant\TenantQueryBuilder[addToNestedQuery]', [$this->getMockQueryBuilder()]);
+        $builder->shouldAllowMockingProtectedMethods();
+        $builder->shouldReceive('addToNestedQuery')->once()->with('where', ['foo', null, null, 'and'])->andReturn($builder);
 
         /* Execution */
         $result = $builder->where('foo');
-        
-        /** Assertion */
+
+        /* Assertion */
         $this->assertEquals($result, $builder);
     }
 
@@ -77,6 +77,7 @@ class TenantQueryBuilderTest extends PHPUnit_Framework_TestCase
         ));
         $builder->macro('fooBar', function ($builder) {
             $_SERVER['__test.builder'] = $builder;
+
             return $builder;
         });
         $result = $builder->fooBar();
@@ -91,10 +92,10 @@ class TenantQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getQuery()->shouldReceive('foobar')->once()->andReturn('foo');
 
         $this->assertInstanceOf('AuraIsHere\LaravelMultiTenant\TenantQueryBuilder', $builder->foobar());
-        
+
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insert')->once()->with(['bar'])->andReturn('foo');
-        
+
         $this->assertEquals('foo', $builder->insert(['bar']));
     }
 
@@ -104,18 +105,20 @@ class TenantQueryBuilderTest extends PHPUnit_Framework_TestCase
     }
 
     protected function getMockModel()
-	{
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
-		$model->shouldReceive('getKeyName')->andReturn('foo');
-		$model->shouldReceive('getTable')->andReturn('foo_table');
-		$model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
-		return $model;
-	}
+    {
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model->shouldReceive('getKeyName')->andReturn('foo');
+        $model->shouldReceive('getTable')->andReturn('foo_table');
+        $model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
+
+        return $model;
+    }
 
     protected function getMockQueryBuilder()
     {
         $query = m::mock('Illuminate\Database\Query\Builder');
         $query->shouldReceive('from')->with('foo_table');
+
         return $query;
     }
 }

--- a/tests/TenantQueryNestingTest.php
+++ b/tests/TenantQueryNestingTest.php
@@ -1,226 +1,226 @@
 <?php
 
-use Mockery as m;
-
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Config;
 use AuraIsHere\LaravelMultiTenant\TenantScope;
 use AuraIsHere\LaravelMultiTenant\Traits\TenantScopedModelTrait;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Mockery as m;
 
 class TenantQueryNestingTest extends PHPUnit_Framework_TestCase
 {
-	protected $model;
-	protected $tenantScope;
+    protected $model;
+    protected $tenantScope;
 
-	public function setUp()
+    public function setUp()
     {
-		$this->tenantScope = new TenantScope;
+        $this->tenantScope = new TenantScope();
 
-		//Mock facades
-		App::shouldReceive('make')->once()->andReturn($this->tenantScope);
-		Config::shouldReceive('get')->with('tenant.default_tenant_columns')->andReturn(['tenant_id']);
+        //Mock facades
+        App::shouldReceive('make')->once()->andReturn($this->tenantScope);
+        Config::shouldReceive('get')->with('tenant.default_tenant_columns')->andReturn(['tenant_id']);
 
-		$this->model = new EloquentBuilderTestNestingStub;
-		$this->mockConnectionForModel($this->model, 'SQLite');
+        $this->model = new EloquentBuilderTestNestingStub();
+        $this->mockConnectionForModel($this->model, 'SQLite');
 
-		//Set tenant
-		$this->tenantScope->addTenant('tenant_id', 1);
-	}
+        //Set tenant
+        $this->tenantScope->addTenant('tenant_id', 1);
+    }
 
-	public function tearDown()
+    public function tearDown()
     {
         m::close();
     }
 
-	/** 
-	 * Test a simple query in which no nesting should occur
-	 */
-	public function testSimpleQuery()
-	{
-		//Reference query
-		$nestedQuery = $this->model->allTenants()->whereRaw("table.tenant_id = '1'");
+    /** 
+     * Test a simple query in which no nesting should occur.
+     */
+    public function testSimpleQuery()
+    {
+        //Reference query
+        $nestedQuery = $this->model->allTenants()->whereRaw("table.tenant_id = '1'");
 
-		//Query to be tested
-		$tenantQuery = $this->model->getQuery();
+        //Query to be tested
+        $tenantQuery = $this->model->getQuery();
 
- 		$this->assertEquals($nestedQuery->getBindings(), $tenantQuery->getBindings());
-		$this->assertEquals($nestedQuery->toSql(), $tenantQuery->toSql());	
-	}
+        $this->assertEquals($nestedQuery->getBindings(), $tenantQuery->getBindings());
+        $this->assertEquals($nestedQuery->toSql(), $tenantQuery->toSql());
+    }
 
-	/** 
-	 * Test shows the original issue in which 'or where' clauses are not nested
-	 * and tests whether it is resolved (meaning: output sql matches a reference query)
-	 */
-	public function testNestingQuery()
-	{
-		//Reference query
-		$nestedQuery = $this->model->allTenants()->whereRaw("table.tenant_id = '1'");
-		$nestedQuery = $this->getTestOuterQuery($nestedQuery);
-		$nestedQuery->where(function($subq) { 
-			$this->getTestSubQuery($subq);
-		});
+    /** 
+     * Test shows the original issue in which 'or where' clauses are not nested
+     * and tests whether it is resolved (meaning: output sql matches a reference query).
+     */
+    public function testNestingQuery()
+    {
+        //Reference query
+        $nestedQuery = $this->model->allTenants()->whereRaw("table.tenant_id = '1'");
+        $nestedQuery = $this->getTestOuterQuery($nestedQuery);
+        $nestedQuery->where(function ($subq) {
+            $this->getTestSubQuery($subq);
+        });
 
-		//Query to be tested
-		$tenantQuery = $this->getTestOuterQuery($this->model->newQuery());
-		$tenantQuery = $this->getTestSubQuery($tenantQuery);
+        //Query to be tested
+        $tenantQuery = $this->getTestOuterQuery($this->model->newQuery());
+        $tenantQuery = $this->getTestSubQuery($tenantQuery);
 
- 		$this->assertEquals($nestedQuery->getQuery()->getRawBindings(), $tenantQuery->getQuery()->getRawBindings());
-		$this->assertEquals($nestedQuery->toSql(), $tenantQuery->toSql());
-	}
+        $this->assertEquals($nestedQuery->getQuery()->getRawBindings(), $tenantQuery->getQuery()->getRawBindings());
+        $this->assertEquals($nestedQuery->toSql(), $tenantQuery->toSql());
+    }
 
-	/** 
-	 * Tested seperately due to relation queries now using hash
-	 * as temporary table names, so can only verify string lengths
-	 * and bindings match
-	 */
-	public function testWhereHasNestingQuery()
-	{
-		//Reference query
-		$nestedQuery = $this->model->allTenants()->whereRaw("table.tenant_id = '1'");
-		$nestedQuery = $this->getTestOuterQuery($nestedQuery);
-		$nestedQuery->where(function($subq) { 
-			$this->getTestHasQuery($subq);
-		});
+    /** 
+     * Tested seperately due to relation queries now using hash
+     * as temporary table names, so can only verify string lengths
+     * and bindings match.
+     */
+    public function testWhereHasNestingQuery()
+    {
+        //Reference query
+        $nestedQuery = $this->model->allTenants()->whereRaw("table.tenant_id = '1'");
+        $nestedQuery = $this->getTestOuterQuery($nestedQuery);
+        $nestedQuery->where(function ($subq) {
+            $this->getTestHasQuery($subq);
+        });
 
-		//Query to be tested
-		$tenantQuery = $this->getTestOuterQuery($this->model->newQuery());
-		$tenantQuery = $this->getTestHasQuery($tenantQuery);
+        //Query to be tested
+        $tenantQuery = $this->getTestOuterQuery($this->model->newQuery());
+        $tenantQuery = $this->getTestHasQuery($tenantQuery);
 
- 		$this->assertEquals($nestedQuery->getQuery()->getRawBindings(), $tenantQuery->getQuery()->getRawBindings());
-		$this->assertEquals(strlen($nestedQuery->toSql()), strlen($tenantQuery->toSql()) );
-	}
+        $this->assertEquals($nestedQuery->getQuery()->getRawBindings(), $tenantQuery->getQuery()->getRawBindings());
+        $this->assertEquals(strlen($nestedQuery->toSql()), strlen($tenantQuery->toSql()));
+    }
 
-	/** 
-	 * Test whether builder with multiple global scopes produces
-	 *  correctly nested queries
-	 */
-	public function testGlobalScopeNestingQuery()
-	{
-		$globalScopeModel = new EloquentBuilderTestGlobalScopeStub;
-		$globalScopeModel::addGlobalScope(new GlobalScopeStub);
-		$this->mockConnectionForModel($globalScopeModel, 'SQLite');
+    /** 
+     * Test whether builder with multiple global scopes produces
+     *  correctly nested queries.
+     */
+    public function testGlobalScopeNestingQuery()
+    {
+        $globalScopeModel = new EloquentBuilderTestGlobalScopeStub();
+        $globalScopeModel::addGlobalScope(new GlobalScopeStub());
+        $this->mockConnectionForModel($globalScopeModel, 'SQLite');
 
-		//Reference query
-		$nestedQuery = $this->model
-							->allTenants()
-							->whereRaw("table.tenant_id = '1'")
-							->where(function($iq1) {
-								$iq1->whereRaw('"table"."deleted_at" is null');
-							})
-							->where(function($iq2) {
-								$iq2->where('baz', '<>', 1)
-									->orWhere('foo', '=', 2);
-							});
+        //Reference query
+        $nestedQuery = $this->model
+                            ->allTenants()
+                            ->whereRaw("table.tenant_id = '1'")
+                            ->where(function ($iq1) {
+                                $iq1->whereRaw('"table"."deleted_at" is null');
+                            })
+                            ->where(function ($iq2) {
+                                $iq2->where('baz', '<>', 1)
+                                    ->orWhere('foo', '=', 2);
+                            });
 
-		//Query to be tested
-		$tenantQuery = $globalScopeModel->newQuery();
+        //Query to be tested
+        $tenantQuery = $globalScopeModel->newQuery();
 
- 		$this->assertEquals($nestedQuery->getQuery()->getRawBindings(), $tenantQuery->getQuery()->getRawBindings());
-		$this->assertEquals($nestedQuery->toSql(), $tenantQuery->toSql());	
-	}
+        $this->assertEquals($nestedQuery->getQuery()->getRawBindings(), $tenantQuery->getQuery()->getRawBindings());
+        $this->assertEquals($nestedQuery->toSql(), $tenantQuery->toSql());
+    }
 
-	public function testSoftDeletingMacrosAreSet()
-	{
-		$globalScopeModel = new EloquentBuilderTestGlobalScopeStub;
-		$tenantQuery = $globalScopeModel->newQuery();
+    public function testSoftDeletingMacrosAreSet()
+    {
+        $globalScopeModel = new EloquentBuilderTestGlobalScopeStub();
+        $tenantQuery = $globalScopeModel->newQuery();
 
- 		$this->assertEquals($tenantQuery, $tenantQuery->withTrashed());
-	}
+        $this->assertEquals($tenantQuery, $tenantQuery->withTrashed());
+    }
 
-	/** 
-	 * A query showcasing many clauses 
-	 */
-	protected function getTestSubQuery($base)
-	{
-		return $base->where('foo', '=', 2)
-					->orWhere('bar', '=', 3)
-					->orWhereBetween('baz', [4, 5])
-					->orWhereNotNull('quux')
-					->whereBazOrBar(6, 7)	//dynamic where
-					->orWhere(function($query)
-            		{
-                		$query->where('wibble', '=', 11)
-                      		  ->where('wobble', '<>', 12);
-            		})
-            		->orWhereExists(function($query)
-		            {
-		                $query->select('id')
-		                      ->from('wobbles')
-		                      ->whereRaw('wobbles.wibble_id = wibbles.id');
-		            });
-	}
+    /** 
+     * A query showcasing many clauses.
+     */
+    protected function getTestSubQuery($base)
+    {
+        return $base->where('foo', '=', 2)
+                    ->orWhere('bar', '=', 3)
+                    ->orWhereBetween('baz', [4, 5])
+                    ->orWhereNotNull('quux')
+                    ->whereBazOrBar(6, 7)    //dynamic where
+                    ->orWhere(function ($query) {
+                        $query->where('wibble', '=', 11)
+                                ->where('wobble', '<>', 12);
+                    })
+                    ->orWhereExists(function ($query) {
+                        $query->select('id')
+                              ->from('wobbles')
+                              ->whereRaw('wobbles.wibble_id = wibbles.id');
+                    });
+    }
 
+    /** 
+     * A query showcasing whereHas clauses.
+     */
+    protected function getTestHasQuery($base)
+    {
+        return $base->whereHas('selfRelation', function ($query) {
+                        $query->whereFlubOrFlob(13, 14)
+                              ->orWhereNull('plugh');
+                    });
+    }
 
-	/** 
-	 * A query showcasing whereHas clauses
-	 */
-	protected function getTestHasQuery($base)
-	{
-		return $base->whereHas('selfRelation', function($query) {
-		            	$query->whereFlubOrFlob(13,14)
-		            		  ->orWhereNull('plugh');
-		            });
-	}
-
-	/** 
-	 * A query showcasing many clauses 
-	 */
-	protected function getTestOuterQuery($base)
-	{
-		return $base->join('baztable', 'footable.id', '=', 'baztable.foo_id')
-					->leftJoin('quuxtable', 'baz.id', '=', 'quuxtable.baz_id')
-					->orderBy('quux', 'desc')
+    /** 
+     * A query showcasing many clauses.
+     */
+    protected function getTestOuterQuery($base)
+    {
+        return $base->join('baztable', 'footable.id', '=', 'baztable.foo_id')
+                    ->leftJoin('quuxtable', 'baz.id', '=', 'quuxtable.baz_id')
+                    ->orderBy('quux', 'desc')
                     ->groupBy('flbr')
                     ->having('fblr', '>', 8)
-					->distinct()
-					->select('bar')
-					->addSelect('foo')
-					->skip(9)
-					->take(10);
-	}
+                    ->distinct()
+                    ->select('bar')
+                    ->addSelect('foo')
+                    ->skip(9)
+                    ->take(10);
+    }
 
-	protected function mockConnectionForModel($model, $database)
-	{
-		$grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
-		$processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
-		$grammar = new $grammarClass;
-		$processor = new $processorClass;
+    protected function mockConnectionForModel($model, $database)
+    {
+        $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
+        $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
+        $grammar = new $grammarClass();
+        $processor = new $processorClass();
 
-		$connection = m::mock('Illuminate\Database\ConnectionInterface', array('getQueryGrammar' => $grammar, 'getPostProcessor' => $processor));
-		$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface', array('connection' => $connection));
-		
-		$class = get_class($model);
-		$class::setConnectionResolver($resolver);
-	}
+        $connection = m::mock('Illuminate\Database\ConnectionInterface', ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface', ['connection' => $connection]);
 
+        $class = get_class($model);
+        $class::setConnectionResolver($resolver);
+    }
 }
 
 /** Stub for a tenant scoped model */
-class EloquentBuilderTestNestingStub extends Illuminate\Database\Eloquent\Model 
+class EloquentBuilderTestNestingStub extends Illuminate\Database\Eloquent\Model
 {
-	protected $table = 'table';
+    protected $table = 'table';
 
-	function selfRelation() { return $this->hasMany('EloquentBuilderTestNestingStub'); }
-	
-	use TenantScopedModelTrait;
+    public function selfRelation()
+    {
+        return $this->hasMany('EloquentBuilderTestNestingStub');
+    }
+
+    use TenantScopedModelTrait;
 }
 
 class GlobalScopeStub implements Illuminate\Database\Eloquent\ScopeInterface
 {
-	public function apply(Illuminate\Database\Eloquent\Builder $builder, Illuminate\Database\Eloquent\Model $model) 
-	{
-		$model = $builder->getModel();
-		$builder->where('baz', '<>', 1)->orWhere('foo', '=', 2);
-	}
+    public function apply(Illuminate\Database\Eloquent\Builder $builder, Illuminate\Database\Eloquent\Model $model)
+    {
+        $model = $builder->getModel();
+        $builder->where('baz', '<>', 1)->orWhere('foo', '=', 2);
+    }
 
-	public function remove(Illuminate\Database\Eloquent\Builder $builder, Illuminate\Database\Eloquent\Model $model) {}
+    public function remove(Illuminate\Database\Eloquent\Builder $builder, Illuminate\Database\Eloquent\Model $model)
+    {
+    }
 }
 
 /** Stub for a model with multiple global scopes*/
-class EloquentBuilderTestGlobalScopeStub extends Illuminate\Database\Eloquent\Model 
+class EloquentBuilderTestGlobalScopeStub extends Illuminate\Database\Eloquent\Model
 {
-	protected $table = 'table';
-	
-	use tenantScopedModelTrait;
-	use Illuminate\Database\Eloquent\SoftDeletes;
+    protected $table = 'table';
+
+    use tenantScopedModelTrait;
+    use Illuminate\Database\Eloquent\SoftDeletes;
 }

--- a/tests/TenantScopeTest.php
+++ b/tests/TenantScopeTest.php
@@ -29,9 +29,9 @@ class TenantScopeTest extends PHPUnit_Framework_TestCase
 
     public function testApply()
     {
-        $scope   = m::mock('AuraIsHere\LaravelMultiTenant\TenantScope');
+        $scope = m::mock('AuraIsHere\LaravelMultiTenant\TenantScope');
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $model   = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
 
         $scope->shouldDeferMissing();
         $scope->shouldReceive('getModelTenants')->once()->with($model)->andReturn(['column' => 1]);
@@ -46,9 +46,9 @@ class TenantScopeTest extends PHPUnit_Framework_TestCase
 
     public function testRemove()
     {
-        $scope   = m::mock('AuraIsHere\LaravelMultiTenant\TenantScope');
+        $scope = m::mock('AuraIsHere\LaravelMultiTenant\TenantScope');
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $model   = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
 
         $scope->shouldDeferMissing();
         $scope->shouldReceive('getModelTenants')->once()->with($model)->andReturn(['column' => 1]);
@@ -89,7 +89,7 @@ class TenantScopeTest extends PHPUnit_Framework_TestCase
         $scope->shouldDeferMissing();
         $scope->shouldReceive('getTenantId')->once()->andReturn(1);
         $scope->shouldReceive('hasTenant')->once()->andReturn(true);
-        
+
         $model->shouldReceive('getTenantColumns')->once()->andReturn(['column']);
 
         $modelTenants = $scope->getModelTenants($model);
@@ -109,10 +109,10 @@ class TenantScopeTest extends PHPUnit_Framework_TestCase
 
     public function testIsTenantConstraint()
     {
-        $scope        = new TenantScope();
-        $model        = m::mock('Illuminate\Database\Eloquent\Model');
+        $scope = new TenantScope();
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
         $tenantColumn = 'column';
-        $tenantId     = 1;
+        $tenantId = 1;
 
         $model->shouldReceive('getTenantWhereClause')->with($tenantColumn, $tenantId)->andReturn("table.column = '1'");
 
@@ -125,9 +125,9 @@ class TenantScopeTest extends PHPUnit_Framework_TestCase
 
     public function testDisable()
     {
-        $scope   = m::mock('AuraIsHere\LaravelMultiTenant\TenantScope');
+        $scope = m::mock('AuraIsHere\LaravelMultiTenant\TenantScope');
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $model   = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
 
         $scope->shouldDeferMissing();
         $scope->shouldReceive('getModelTenants')->with($model)->andReturn(['column' => 1])->never();

--- a/tests/TenantScopedModelTraitTest.php
+++ b/tests/TenantScopedModelTraitTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Mockery as m;
+use AuraIsHere\LaravelMultiTenant\Traits\TenantScopedModelTrait;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use AuraIsHere\LaravelMultiTenant\Traits\TenantScopedModelTrait;
+use Mockery as m;
 
 class TenantScopedModelTraitTest extends PHPUnit_Framework_TestCase
 {
@@ -38,9 +38,9 @@ class TenantScopedModelTraitTest extends PHPUnit_Framework_TestCase
     public function testFindOrFailThrowsTenantException()
     {
         TenantScopedModelStub::findOrFail(1, []);
-	}
+    }
 
-	public function testNewQueryReturnsTenantQueryBuilder()
+    public function testNewQueryReturnsTenantQueryBuilder()
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
@@ -50,10 +50,10 @@ class TenantScopedModelTraitTest extends PHPUnit_Framework_TestCase
         $conn->shouldReceive('getPostProcessor')->twice()->andReturn($processor);
         TenantScopedModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
         $resolver->shouldReceive('connection')->andReturn($conn);
-        
-        $model = new TenantScopedModelStub;
+
+        $model = new TenantScopedModelStub();
         $builder = $model->newQuery();
-        
+
         $this->assertInstanceOf('AuraIsHere\LaravelMultiTenant\TenantQueryBuilder', $builder);
     }
 }


### PR DESCRIPTION
Proposed solution to issue #62:

The model query now maintains a nested subquery in which it pushes all where-like clauses. This way orWhere and similar clauses do not override the global client scope.

Each global scope (except TenantScope and SoftDeletes) is also nested as a subquery. If needed, other global scopes may implement the LoftyScope interface to get included on the top level query.